### PR TITLE
Remove items duplicated in colors.json

### DIFF
--- a/public/basiccolors.json
+++ b/public/basiccolors.json
@@ -25,7 +25,7 @@
     "family": "blue"
   },
   {
-    "name": "Magenta",
+    "name": "Fuchsia",
     "color": "#FF00FF",
     "family": "purple"
   }

--- a/public/colors.json
+++ b/public/colors.json
@@ -20,11 +20,6 @@
     "family": "red"
   },
   {
-    "name": "LightSalmon",
-    "color": "#FFA07A",
-    "family": "red"
-  },
-  {
     "name": "Crimson",
     "color": "#DC143C",
     "family": "red"
@@ -190,11 +185,6 @@
     "family": "purple"
   },
   {
-    "name": "Magenta",
-    "color": "#FF00FF",
-    "family": "purple"
-  },
-  {
     "name": "MediumOrchid",
     "color": "#BA55D3",
     "family": "purple"
@@ -247,11 +237,6 @@
   {
     "name": "DarkSlateBlue",
     "color": "#483D8B",
-    "family": "purple"
-  },
-  {
-    "name": "MediumSlateBlue",
-    "color": "#7B68EE",
     "family": "purple"
   },
   {
@@ -368,11 +353,6 @@
     "name": "Teal",
     "color": "#008080",
     "family": "green"
-  },
-  {
-    "name": "Aqua",
-    "color": "#00FFFF",
-    "family": "blue"
   },
   {
     "name": "Cyan",


### PR DESCRIPTION
Denne gjer ikkje så myke, vi har fortsatt tilfeller at dupliserte alternativ inne i ei oppgåve. Men det eliminerer vertfall ein punkt for usikkerhet, og tvilar på at vi skal ta oss spesielt med tid til å deduplisere svar-alalternativa, når oppgåva skal inn i dag.

```json
# Eksempel på oppgåve med duplisert svar-alternativ
{"task":{"id":7,"type":"color","buttons":["#FF00FF","#00FFFF","#0000FF","#00FFFF"],"correctAnswer":"#FF00FF","createdAt":"2020-04-27T07:58:17.179Z","updatedAt":"2020-04-27T07:58:17.179Z"}}
```